### PR TITLE
build: Add scripts to clean lock file and resync dependencies after cleaning

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
 		"lint": "next lint",
 		"start": "next start",
 		"find-deadcode": "ts-prune | (! grep -v 'used in module')",
-		"build": "next build && next-sitemap"
+		"build": "next build && next-sitemap",
+		"clean:lock": "rm -f pnpm-lock.yaml",
+		"clean:resync": "pnpm clean:lock && pnpm install"
 	},
 	"dependencies": {
 		"@heroicons/react": "^2.1.3",


### PR DESCRIPTION
Add "clean:lock" script to remove pnpm-lock.yaml file and "clean:resync" script
to run "clean:lock" then reinstall dependencies using pnpm.