### PR TITLE
build: update production deployment workflow

### DIFF
--- a/.github/workflows/production-by-tag.yml
+++ b/.github/workflows/production-by-tag.yml
@@ -1,0 +1,38 @@
+name: Production Tag Deployment (Account)
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  push:
+    # Pattern matched against refs/tags
+    tags-ignore:
+      - '*-staging*' # Exclude tags containing "staging"
+jobs:
+  Deploy-Production-Account:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        node-version: [20.x]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 8
+          run_install: false
+      - name: Install Vercel CLI
+        run: pnpm install -g vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Exclude staging tags from triggering production deployment in the 
.production-by-tag workflow. Update to node.js version 20.x and 
pnpm version 8 for building project artifacts and deploying to Vercel.