### PR TITLE
refactor(site-header): Update profile links to use siteConfig

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -3,13 +3,13 @@ import SiteFooter from "@/components/site-footer";
 import SiteHeader from "@/components/site-header";
 import SkipToContent from "@/components/skip-to-content";
 import { cn } from "@/lib/cn";
+import { siteConfig } from "@/lib/config";
+import { getBaseUrl } from "@/lib/get-base-url";
 import "@/styles/globals.css";
 import type { Metadata } from "next";
 import { Inter as FontSans } from "next/font/google";
 import Script from "next/script";
 import RootProviders from "./root-providers";
-import { siteConfig } from "@/lib/config";
-import { getBaseUrl } from "@/lib/get-base-url";
 
 export const viewport = {
 	themeColor: [

--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -3,20 +3,13 @@ import SiteFooter from "@/components/site-footer";
 import SiteHeader from "@/components/site-header";
 import SkipToContent from "@/components/skip-to-content";
 import { cn } from "@/lib/cn";
-import { DEVDOMAIN, DOMAIN, devEnvironment } from "@/lib/constants";
 import "@/styles/globals.css";
 import type { Metadata } from "next";
 import { Inter as FontSans } from "next/font/google";
 import Script from "next/script";
 import RootProviders from "./root-providers";
-
-const title = "Kyle Wong - Digital Marketer, Web Developer.";
-const description = `Hello, I'm Kyle, a digital marketer and web developer, based in the Malaysia 🇲.`;
-const image = encodeURI(
-	`${
-		devEnvironment ? DEVDOMAIN : DOMAIN
-	}/api/og-image/Kyle Wong - Digital Marketer, Web Developer.`,
-);
+import { siteConfig } from "@/lib/config";
+import { getBaseUrl } from "@/lib/get-base-url";
 
 export const viewport = {
 	themeColor: [
@@ -26,9 +19,12 @@ export const viewport = {
 };
 
 export const metadata: Metadata = {
-	metadataBase: new URL("https://kylewong.my"),
-	title,
-	description,
+	metadataBase: new URL(siteConfig.url),
+	title: {
+		default: `${siteConfig.name} - Digital Marketer, Web Developer.`,
+		template: `%s - ${siteConfig.name} - Digital Marketer, Web Developer.`,
+	},
+	description: siteConfig.description,
 	keywords: [
 		"Digital Marketing",
 		"Web Development",
@@ -38,54 +34,50 @@ export const metadata: Metadata = {
 	],
 	authors: [
 		{
-			name: "kyle",
-			url: "https://kylewong.my",
+			name: siteConfig.name,
+			url: siteConfig.url,
 		},
 	],
+	robots: {
+		index: true,
+		follow: true,
+		nocache: false,
+	},
 	creator: "kyle",
 	openGraph: {
-		title,
-		description,
-		url: DOMAIN,
-		siteName: title,
-		images: [image],
-		locale: "en-US",
 		type: "website",
+		locale: "en_US",
+		url: getBaseUrl(siteConfig.url),
+		title: siteConfig.name,
+		description: siteConfig.description,
+		siteName: siteConfig.name,
+		images: [
+			{
+				url: siteConfig.ogImage,
+				width: 1200,
+				height: 628,
+				alt: siteConfig.name,
+			},
+		],
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: siteConfig.name,
+		description: siteConfig.description,
+		images: [siteConfig.ogImage],
 	},
 	icons: {
-		icon: [
-			{
-				url: "/favicon/favicon-32x32.png",
-				sizes: "32x32",
-				type: "image/png",
-			},
-			{
-				url: "/favicon/favicon-16x16.png",
-				sizes: "16x16",
-				type: "image/png",
-			},
-		],
-		shortcut: ["/favicon/favicon.ico"],
-		apple: [
-			{
-				url: "/favicon/apple-touch-icon.png",
-				sizes: "180x180",
-				type: "image/png",
-			},
-		],
 		other: [
 			{
 				rel: "mask-icon",
-				url: "/favicon/safari-pinned-tab.svg",
+				url: "/safari-pinned-tab.svg",
+				color: "#274b50",
 			},
 		],
 	},
-	manifest: "/favicon/site.webmanifest",
-	twitter: {
-		card: "summary_large_image",
-		title,
-		description,
-		images: [image],
+	manifest: "/site.webmanifest",
+	alternates: {
+		canonical: getBaseUrl(siteConfig.url),
 	},
 	formatDetection: {
 		email: false,

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -3,12 +3,6 @@ import Experiences from "@/components/homepage/experiences";
 import Posts from "@/components/homepage/posts";
 import Projects from "@/components/homepage/projects";
 
-export const metadata = {
-	alternates: {
-		canonical: "/",
-	},
-};
-
 function Page(): JSX.Element {
 	return (
 		<>

--- a/src/app/(main)/posts/[slug]/layout.tsx
+++ b/src/app/(main)/posts/[slug]/layout.tsx
@@ -1,8 +1,9 @@
-import { DEVDOMAIN, DOMAIN, devEnvironment } from "@/lib/constants";
 import { createReader } from "@keystatic/core/reader";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import config from "../../../../../keystatic.config";
+import { siteConfig } from "@/lib/config";
+import { generateCustomMetadata } from "@/lib/generate-custom-metadata";
 
 const reader = createReader(process.cwd(), config);
 
@@ -17,35 +18,17 @@ export async function generateMetadata({
 	//
 	if (!post) return notFound();
 
-	const title = `${post.title} | Kyle's Blog`;
+	const title = post.title;
 	const description = post.description;
-	const image = encodeURI(
-		`${devEnvironment ? DEVDOMAIN : DOMAIN}/api/og-image/${post.title}`,
-	);
-	const date = post.date
-		? new Date(post.date).toISOString()
-		: new Date().toISOString();
-
-	return {
-		title,
-		description,
-		openGraph: {
-			title,
-			description,
-			url: `${DOMAIN}/posts/${params.slug}`,
-			siteName: title,
-			images: [image],
-			locale: "en-US",
-			type: "article",
-			publishedTime: date,
-		},
-		twitter: {
-			card: "summary_large_image",
-			title,
-			description,
-			images: [image],
-		},
-	};
+	const slug = `/posts/${params.slug}`;
+	const image = encodeURI(`${siteConfig.url}/api/og-image/${post.title}`);
+	return generateCustomMetadata({
+		mainTitle: title,
+		maybeSeoTitle: title,
+		maybeSeoDescription: description,
+		ogImage: image,
+		slug,
+	});
 }
 
 interface PostLayoutProps {

--- a/src/app/(main)/posts/[slug]/layout.tsx
+++ b/src/app/(main)/posts/[slug]/layout.tsx
@@ -1,9 +1,9 @@
+import { siteConfig } from "@/lib/config";
+import { generateCustomMetadata } from "@/lib/generate-custom-metadata";
 import { createReader } from "@keystatic/core/reader";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import config from "../../../../../keystatic.config";
-import { siteConfig } from "@/lib/config";
-import { generateCustomMetadata } from "@/lib/generate-custom-metadata";
 
 const reader = createReader(process.cwd(), config);
 

--- a/src/app/(main)/posts/page.tsx
+++ b/src/app/(main)/posts/page.tsx
@@ -1,11 +1,11 @@
 import { cn } from "@/lib/cn";
+import { siteConfig } from "@/lib/config";
+import { generateCustomMetadata } from "@/lib/generate-custom-metadata";
 import { ChevronLeftIcon } from "@heroicons/react/20/solid";
 import { createReader } from "@keystatic/core/reader";
 import dayjs from "dayjs";
 import Link from "next/link";
 import config from "../../../../keystatic.config";
-import { siteConfig } from "@/lib/config";
-import { generateCustomMetadata } from "@/lib/generate-custom-metadata";
 
 const title = "Post List";
 const description = "A list for all my blogs and sharings";

--- a/src/app/(main)/posts/page.tsx
+++ b/src/app/(main)/posts/page.tsx
@@ -1,38 +1,26 @@
 import { cn } from "@/lib/cn";
-import { DEVDOMAIN, DOMAIN, devEnvironment } from "@/lib/constants";
 import { ChevronLeftIcon } from "@heroicons/react/20/solid";
 import { createReader } from "@keystatic/core/reader";
 import dayjs from "dayjs";
 import Link from "next/link";
 import config from "../../../../keystatic.config";
+import { siteConfig } from "@/lib/config";
+import { generateCustomMetadata } from "@/lib/generate-custom-metadata";
 
-const title = "Post List | Kyle Wong";
+const title = "Post List";
 const description = "A list for all my blogs and sharings";
 const image = encodeURI(
-	`${
-		devEnvironment ? DEVDOMAIN : DOMAIN
-	}/api/og-image/A list for all my blogs and sharings`,
+	`${siteConfig.url}/api/og-image/A list for all my blogs and sharings`,
 );
+const slug = "/posts";
 
-export const metadata = {
-	title,
-	description,
-	openGraph: {
-		title,
-		description,
-		url: DOMAIN,
-		siteName: title,
-		images: [image],
-		locale: "en-US",
-		type: "website",
-	},
-	twitter: {
-		card: "summary_large_image",
-		title,
-		description,
-		images: [image],
-	},
-};
+export const metadata = generateCustomMetadata({
+	mainTitle: title,
+	maybeSeoTitle: title,
+	maybeSeoDescription: description,
+	ogImage: image,
+	slug,
+});
 
 const reader = createReader(process.cwd(), config);
 

--- a/src/components/homepage/experiences.tsx
+++ b/src/components/homepage/experiences.tsx
@@ -1,11 +1,11 @@
 import { Badge } from "@/components/ui/badge";
 import { LinkTag } from "@/components/ui/typography/link-tag";
-import { linkedInProfile } from "@/lib/constants";
 import { formatDateRange } from "@/lib/dates";
 import { createReader } from "@keystatic/core/reader";
 import dayjs from "dayjs";
 import { TbExternalLink } from "react-icons/tb";
 import config from "../../../keystatic.config";
+import { siteConfig } from "@/lib/config";
 
 const reader = createReader(process.cwd(), config);
 
@@ -73,7 +73,7 @@ async function Experiences(): Promise<JSX.Element> {
 
 			<LinkTag
 				className="flex items-center gap-2"
-				href={linkedInProfile}
+				href={siteConfig.links.linkedin}
 				target="_blank"
 				rel="noreferrer noopener"
 			>

--- a/src/components/homepage/experiences.tsx
+++ b/src/components/homepage/experiences.tsx
@@ -1,11 +1,11 @@
 import { Badge } from "@/components/ui/badge";
 import { LinkTag } from "@/components/ui/typography/link-tag";
+import { siteConfig } from "@/lib/config";
 import { formatDateRange } from "@/lib/dates";
 import { createReader } from "@keystatic/core/reader";
 import dayjs from "dayjs";
 import { TbExternalLink } from "react-icons/tb";
 import config from "../../../keystatic.config";
-import { siteConfig } from "@/lib/config";
 
 const reader = createReader(process.cwd(), config);
 

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,4 +1,5 @@
-import { githubProfile, githubRepo } from "@/lib/constants";
+import { siteConfig } from "@/lib/config";
+import { githubRepo } from "@/lib/constants";
 import React from "react";
 
 function SiteFooter(): JSX.Element {
@@ -7,7 +8,7 @@ function SiteFooter(): JSX.Element {
 			<p className="text-center text-sm leading-loose md:text-left">
 				Built by{" "}
 				<a
-					href={githubProfile}
+					href={siteConfig.links.github}
 					target="_blank"
 					rel="noreferrer noopener"
 					className="group font-medium text-foreground transition-all duration-300 ease-in-out "

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,11 +1,11 @@
 import { cn } from "@/lib/cn";
-import { githubProfile, linkedInProfile } from "@/lib/constants";
 import { AiFillGithub, AiFillLinkedin } from "react-icons/ai";
 import DarkModeToggle from "./dark-mode-toggle";
 import SiteNav from "./site-nav";
 import TraworldHover from "./traworld-hover";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { buttonVariants } from "./ui/button";
+import { siteConfig } from "@/lib/config";
 
 function SiteHeader(): JSX.Element {
 	return (
@@ -33,7 +33,7 @@ function SiteHeader(): JSX.Element {
 			<ul className="mt-10 flex items-center gap-2">
 				<li className="text-xs">
 					<a
-						href={linkedInProfile}
+						href={siteConfig.links.linkedin}
 						target="_blank"
 						rel="noreferrer noopener"
 						className={cn(
@@ -50,7 +50,7 @@ function SiteHeader(): JSX.Element {
 				</li>
 				<li className="text-xs">
 					<a
-						href={githubProfile}
+						href={siteConfig.links.github}
 						target="_blank"
 						rel="noreferrer noopener"
 						className={cn(

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,11 +1,11 @@
 import { cn } from "@/lib/cn";
+import { siteConfig } from "@/lib/config";
 import { AiFillGithub, AiFillLinkedin } from "react-icons/ai";
 import DarkModeToggle from "./dark-mode-toggle";
 import SiteNav from "./site-nav";
 import TraworldHover from "./traworld-hover";
 import { Avatar, AvatarFallback, AvatarImage } from "./ui/avatar";
 import { buttonVariants } from "./ui/button";
-import { siteConfig } from "@/lib/config";
 
 function SiteHeader(): JSX.Element {
 	return (

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,17 @@
+import { DEVDOMAIN, DOMAIN, devEnvironment } from "./constants";
+
+export const siteConfig = {
+	name: "Kyle Wong",
+	url: devEnvironment ? DEVDOMAIN : DOMAIN,
+	ogImage: encodeURI(
+		`${
+			devEnvironment ? DEVDOMAIN : DOMAIN
+		}/api/og-image/Kyle Wong - Digital Marketer, Web Developer.`,
+	),
+	description:
+		"Hello, I'm Kyle, a digital marketer and web developer, based in the Malaysia 🇲.",
+	links: {
+		github: "https://www.github.com/y3owk1n",
+		linkedin: "https://www.linkedin.com/in/kyle-wong-958a58115/",
+	},
+};

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -3,10 +3,7 @@ export const siteDescription = "My personal site with lots of stuffs";
 export const blurDataURL =
 	"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8MmFbPQAHdQK78xXbewAAAABJRU5ErkJggg==";
 
-export const DOMAIN = "https://www.kylewong.my";
+export const DOMAIN = "https://kylewong.my";
 export const DEVDOMAIN = "http://localhost:3000";
 export const devEnvironment = process.env.NODE_ENV === "development";
-export const githubProfile = "https://www.github.com/y3owk1n";
-export const linkedInProfile =
-	"https://www.linkedin.com/in/kyle-wong-958a58115/";
 export const githubRepo = "https://github.com/y3owk1n/blog";

--- a/src/lib/generate-custom-metadata.ts
+++ b/src/lib/generate-custom-metadata.ts
@@ -1,0 +1,73 @@
+import { siteConfig } from "@/lib/config";
+import { type Metadata } from "next";
+import { getBaseUrl } from "./get-base-url";
+
+export function generateCustomMetadata({
+	mainTitle,
+	maybeSeoTitle,
+	maybeSeoDescription,
+	slug,
+	ogImage,
+	ogImageAlt,
+	disallowRobotIndex = false,
+}: {
+	mainTitle: string;
+	maybeSeoTitle: string;
+	maybeSeoDescription: string;
+	slug: string;
+	ogImage?: string;
+	ogImageAlt?: string;
+	disallowRobotIndex?: boolean;
+}): Metadata {
+	let robotsMeta: Metadata["robots"] = {
+		index: true,
+		follow: true,
+		nocache: false,
+	};
+
+	if (disallowRobotIndex) {
+		robotsMeta = {
+			index: false,
+			follow: false,
+			nocache: true,
+			noarchive: true,
+			nosnippet: true,
+			noimageindex: true,
+			notranslate: true,
+			nositelinkssearchbox: true,
+			"max-snippet": -1,
+			"max-image-preview": "none",
+			"max-video-preview": -1,
+		};
+	}
+
+	return {
+		title: mainTitle,
+		description: maybeSeoDescription,
+		openGraph: {
+			type: "website",
+			locale: "en_US",
+			url: siteConfig.url,
+			title: maybeSeoTitle,
+			description: maybeSeoDescription,
+			images: [
+				{
+					url: ogImage ?? siteConfig.ogImage,
+					width: 1200,
+					height: 628,
+					alt: ogImageAlt ?? siteConfig.name,
+				},
+			],
+		},
+		twitter: {
+			card: "summary_large_image",
+			title: maybeSeoTitle,
+			description: maybeSeoDescription,
+			images: [ogImage ?? siteConfig.ogImage],
+		},
+		alternates: {
+			canonical: getBaseUrl(siteConfig.url, slug),
+		},
+		robots: robotsMeta,
+	};
+}

--- a/src/lib/get-base-url.ts
+++ b/src/lib/get-base-url.ts
@@ -1,0 +1,13 @@
+export function getBaseUrl(baseUrl: string, slug?: string): string {
+	const url = new URL(baseUrl);
+
+	if (slug) {
+		if (!slug.startsWith("/")) {
+			url.pathname = `${url.pathname}${slug}`;
+		} else {
+			url.pathname = `${url.pathname}${slug.replace("/", "")}`;
+		}
+	}
+
+	return url.toString();
+}


### PR DESCRIPTION
- Replace direct profile links with siteConfig links for LinkedIn and GitHub
- Use siteConfig to centralize profile links and configurations.